### PR TITLE
Update runtime to 49

### DIFF
--- a/io.github.mezoahmedii.Picker.json
+++ b/io.github.mezoahmedii.Picker.json
@@ -1,7 +1,7 @@
 {
     "id": "io.github.mezoahmedii.Picker",
     "runtime": "org.gnome.Platform",
-    "runtime-version": "48",
+    "runtime-version": "49",
     "sdk": "org.gnome.Sdk",
     "command": "picker",
     "finish-args": [
@@ -10,37 +10,7 @@
         "--device=dri",
         "--socket=wayland"
     ],
-    "cleanup": [
-        "/include",
-        "/lib/pkgconfig",
-        "/man",
-        "/share/doc",
-        "/share/gtk-doc",
-        "/share/man",
-        "/share/pkgconfig",
-        "*.la",
-        "*.a"
-    ],
     "modules": [
-        {
-            "name": "blueprint-compiler",
-            "buildsystem": "meson",
-            "cleanup": [
-                "*"
-            ],
-            "sources": [
-                {
-                    "type": "git",
-                    "url": "https://gitlab.gnome.org/GNOME/blueprint-compiler",
-                    "tag": "v0.20.0",
-                    "x-checker-data": {
-                        "type": "git",
-                        "tag-pattern": "^v([\\d.]+)$"
-                    },
-                    "commit": "aa5298cc1677cf855bd61f9671607362bd203f4f"
-                }
-            ]
-        },
         {
             "name": "Picker",
             "buildsystem": "meson",


### PR DESCRIPTION
- Update runtime to 49
- Drop the blueprint compiler, which is  already provided by the runtime
- Drop cleanup commands (none of them were present in the Flatpak file)